### PR TITLE
Remove inheritance from object in python3.

### DIFF
--- a/scratchdir.py
+++ b/scratchdir.py
@@ -51,7 +51,7 @@ def requires_activation(func):
     return decorator
 
 
-class ScratchDir(object):
+class ScratchDir:
     """
     Represents a directory on disk within the default temporary directory that can be used to store context
     specific subdirectories and files.


### PR DESCRIPTION
Fixes linter error:

* scratchdir.py:54:0: R0205: Class 'ScratchDir' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)