### PR TITLE
Freeze pylint/mypy/pytest versions for py34 since deprecation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ changelog:   ## Build CHANGELOG.md.
 
 .PHONY: build-install
 build-install:  ## Install dependencies required for local package building.
-	@pip install -q -r requirements/build.txt
+	@pip install -r requirements/build.txt
 
 .PHONY: test-install
 test-install: build-install  ## Install dependencies required for local test execution.
-	@pip install -q -r requirements/test.txt
+	@pip install -r requirements/test.txt
 
 .PHONY: test
 test: test-install  ## Run test suite.
@@ -18,7 +18,7 @@ test: test-install  ## Run test suite.
 
 .PHONY: tox-install
 tox-install: build-install  ## Install dependencies required for local test execution using tox.
-	@pip install -q -r requirements/tox.txt
+	@pip install -r requirements/tox.txt
 
 .PHONY: tox
 tox: tox-install  ## Run test suite using tox.
@@ -26,12 +26,12 @@ tox: tox-install  ## Run test suite using tox.
 
 .PHONY: travis-install
 travis-install: build-install  ## Install dependencies for travis-ci.org integration.
-	@pip install -q -r requirements/travis.txt
+	@pip install -r requirements/travis.txt
 
 .PHONY: travis-before-script
 travis-before-script: travis-install  ## Entry point for travis-ci.org 'before_script' execution.
-	@curl -s https://codecov.io/bash > ./codecov
-	@chmod +x ./codecov
+	curl -s https://codecov.io/bash > ./codecov
+	chmod +x ./codecov
 
 .PHONY: travis-script
 travis-script: travis-install tox  ## Entry point for travis-ci.org execution.

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,6 +2,5 @@
 #
 # Requirements necessary to build the scratchdir package.
 
-pip==19.2.3
 setuptools==36.8.0; python_version < '2.7'  # pyup: ignore
 setuptools==41.2.0; python_version > '2.7'

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,8 +5,9 @@
 -r base.txt
 
 bumpversion==0.5.3
-mypy==0.730
-pylint==1.7.5; python_version < '3.4'  # pyup: ignore
+mypy==0.670; python_version <= '3.4'  # pyup: ignore
+mypy==0.730; python_version > '3.4'
+pylint==2.3.1; python_version == '3.4'  # pyup: ignore
 pylint==2.4.2; python_version > '3.4'
 bandit==1.6.2
 safety==1.8.5

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,8 @@ pathlib2==2.3.5; python_version <= '3.3'
 coverage==4.5.4
 
 pytest<3.3.0; python_version < '3.4'  # pyup: ignore
-pytest==5.2.0; python_version >= '3.4'
+pytest==4.6.5; python_version == '3.4'  # pyup: ignore
+pytest==5.2.0; python_version > '3.4'
 pytest-cov==2.7.1
 pytest-mock==1.6.3; python_version < '3.4'  # pyup: ignore
 pytest-mock==1.11.0; python_version >= '3.4'

--- a/scratchdir.py
+++ b/scratchdir.py
@@ -294,6 +294,8 @@ class ScratchDir:
         :return: Path in scratch dir for unique filename
         :rtype: :class:`~str`
         """
+        prefix = prefix if prefix is not None else ''
+        suffix = suffix if suffix is not None else ''
         return self.join(''.join((prefix, str(uuid.uuid4()), suffix)))
 
     @requires_activation

--- a/scratchdir.py
+++ b/scratchdir.py
@@ -24,6 +24,9 @@ else:
     DEFAULT_PREFIX = 'tmp'
     DEFAULT_SUFFIX = ''
 
+# Default working directory value.
+DEFAULT_WD = ''
+
 
 class ScratchDirError(Exception):
     """
@@ -58,7 +61,7 @@ class ScratchDir:
     """
 
     def __init__(self, prefix: str = '', suffix: str = '.scratchdir', base: typing.Optional[str] = None,
-                 root: typing.Optional[str] = tempfile.tempdir, wd: typing.Optional[str] = None) -> None:
+                 root: typing.Optional[str] = tempfile.tempdir, wd: str = DEFAULT_WD) -> None:
         self.prefix = prefix
         self.suffix = suffix
         self.base = base
@@ -105,7 +108,7 @@ class ScratchDir:
         :rtype: :class:`~NoneType`
         """
         shutil.rmtree(self.wd)
-        self.wd = None
+        self.wd = DEFAULT_WD
 
     @requires_activation
     def child(self, prefix: str = '', suffix: str = '.scratchdir') -> 'ScratchDir':

--- a/tests.py
+++ b/tests.py
@@ -123,7 +123,7 @@ def test_scratch_setup_assigns_wd(scratch_dir):
     Assert that :attr:`~scratchdir.ScratchDir.wd` is set after :meth:`~scratchdir.ScratchDir.setup` is called.
     """
     with scratch_dir:
-        assert scratch_dir.wd is not None
+        assert scratch_dir.wd != scratchdir.DEFAULT_WD
 
 
 def test_scratch_teardown_unassigns_wd(scratch_dir):
@@ -132,7 +132,7 @@ def test_scratch_teardown_unassigns_wd(scratch_dir):
     """
     with scratch_dir:
         pass
-    assert scratch_dir.wd is None
+    assert scratch_dir.wd == scratchdir.DEFAULT_WD
 
 
 def test_scratch_teardown_removes_files(scratch_dir, mocker):


### PR DESCRIPTION
This should fix broken Travis builds that are failing to find pylint 2.4.2 for py3.4.

