### PR TITLE
Remove mocker context manager usage as its now deprecated

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -56,19 +56,19 @@ def test_scratch_enter_calls_setup(scratch_dir, mocker):
     """
     Assert that :meth:`~scratchdir.ScratchDir.__enter__` calls :meth:`~scratchdir.ScratchDir.setup`.
     """
-    with mocker.patch.object(scratch_dir, 'setup', wraps=scratch_dir.setup):
-        with scratch_dir:
-            assert scratch_dir.setup.called
+    mocker.patch.object(scratch_dir, 'setup', wraps=scratch_dir.setup)
+    with scratch_dir:
+        assert scratch_dir.setup.called
 
 
 def test_scratch_exit_calls_teardown(scratch_dir, mocker):
     """
     Assert that :meth:`~scratchdir.ScratchDir.__exit__` calls :meth:`~scratchdir.ScratchDir.teardown`.
     """
-    with mocker.patch.object(scratch_dir, 'teardown', wraps=scratch_dir.teardown):
-        with scratch_dir:
-            pass
-        assert scratch_dir.teardown.called
+    mocker.patch.object(scratch_dir, 'teardown', wraps=scratch_dir.teardown)
+    with scratch_dir:
+        pass
+    assert scratch_dir.teardown.called
 
 
 def test_scratch_is_not_active_when_wd_not_set(scratch_dir):


### PR DESCRIPTION
See: https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager

<blockquote><img src="https://avatars3.githubusercontent.com/u/8897583?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/pytest-dev/pytest-mock">pytest-dev/pytest-mock</a></strong></div><div>Thin-wrapper around the mock package for easier use with py.test - pytest-dev/pytest-mock</div></blockquote>